### PR TITLE
商品削除機能の実装。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
+    if user_signed_in? &&  current_user.id == @item.user_id
+      @item.destroy
       redirect_to root_path
     end
     

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,9 +36,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in? &&  current_user.id == @item.user_id
+    if current_user.id == @item.user_id 
       @item.destroy
       redirect_to root_path
+    else
+      render :show
     end
     
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:show, :edit, :update ]
+  before_action :set_item, only: [:show, :edit, :update, :destroy ]
   before_action :move_to_index, only: :edit
   
   def index
@@ -33,6 +33,13 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    end
+    
   end
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? &&  current_user.id == @item.user_id%>
     <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update ]
+  resources :items
   
 end


### PR DESCRIPTION
what
商品の削除機能を実装しました。
why
この機能追加により登録している商品情報を削除することができるため

商品情報の削除が成功してトップページに移動するgyazo gif
https://gyazo.com/69c083ff5aa3a7888c50cba8f5b2dd84

レビューお願いいたします。